### PR TITLE
Use short-lived connections for publisher

### DIFF
--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -9,7 +9,7 @@ var defaults = {
   producerId: null
 }
 
-function send(socket, producer, topic, data) {
+function send(address, producer, topic, data) {
   var evt = evtFactory.getInstance(producer, topic, data)
 
   var logData = _.pick(evt, ['producer', 'timestamp', 'topic', 'uuid'])
@@ -17,7 +17,10 @@ function send(socket, producer, topic, data) {
   //in the logs the non serialized data should be present
   log.debug(logData, 'Published event to topic %s', topic)
 
+  var socket = zmq.socket('dealer')
+  socket.connect(address)
   socket.send(evt.toFrames())
+  socket.disconnect(address)
 }
 
 function getInstance(configuration) {
@@ -25,13 +28,10 @@ function getInstance(configuration) {
 
   if (!config.producerId){ throw new Error('Invalid producer id') }
 
-  var socket = zmq.socket('dealer')
-  socket.connect(config.address)
-
   log.info("Producer '%s' opened a publisher stream to %s",
     config.producerId, config.address)
 
-  return { send: _.partial(send, socket, config.producerId) }
+  return { send: _.partial(send, config.address, config.producerId) }
 }
 
 module.exports = { getInstance: getInstance }

--- a/test/support/zmq_helper.js
+++ b/test/support/zmq_helper.js
@@ -3,6 +3,7 @@ var sinon = require('sinon')
 function getSocketStub() {
   return {
     connect: sinon.spy(),
+    disconnect: sinon.spy(),
     subscribe: sinon.spy(),
     on: sinon.spy(),
     unref: sinon.spy(),


### PR DESCRIPTION
As we learned if connections are idle for long time(more than 24 hours)
then they can break for various reasons. So we either need to use keep
alive or use short-lived connections. Since having keep alive will
probably end up sending a lot more packets than needs to send, and short
lived connections are not expensive, and more maintanble, we now use
short lived connections. For each event a connection is made, payload is
sent and immidetialy the connection is closed afterwards.

This will make the publisher more reliable